### PR TITLE
Fix condition for pushing PKCE query params.

### DIFF
--- a/OidcDebugger/Views/Home/index.js
+++ b/OidcDebugger/Views/Home/index.js
@@ -56,7 +56,7 @@ new Vue({
             result.params.push({ name: 'response_type', hintName: 'response_type_hint', value: this.responseType.trim() });
             result.params.push({ name: 'response_mode', hintName: 'response_mode_hint', value: this.responseMode.trim() });
 
-            if (this.responseTypesArray.indexOf('code') > -1 && this.pkceMethod != 'disabled') {
+            if (this.responseTypesArray.indexOf('code') > -1 && this.usePkce) {
                 result.params.push({ name: 'code_challenge_method', value: this.pkceMethod.trim() });
                 result.params.push({ name: 'code_challenge', value: this.pkceCodeChallenge.trim() });
             }

--- a/OidcDebugger/Views/Shared/utils.js
+++ b/OidcDebugger/Views/Shared/utils.js
@@ -25,9 +25,6 @@ export function hash(codeChallengeMethod, plainText) {
     if (codeChallengeMethod == 'plain')
         return Promise.resolve(plainText);
 
-    else if (codeChallengeMethod == 'disabled')
-        return Promise.resolve('disabled');
-
     else {
         var encoder = new TextEncoder();
         var algorithm = getAlgorithm(codeChallengeMethod);


### PR DESCRIPTION
Fixes #76 

At some point during the development of the PKCE implementation, we switched from using just a radio field to a combination of a radio field and checkbox. It is no longer possible for the `pkceMethod` variable to have a value of `'disabled'`, so the query parameters were always being added to the auth request.

This PR changes the condition for adding PKCE related query parameters to instead use the `usePkce` checkbox value.